### PR TITLE
Force using OpenJDK 11 in COPR builds

### DIFF
--- a/ovirt-engine-api-metamodel.spec.in
+++ b/ovirt-engine-api-metamodel.spec.in
@@ -66,6 +66,9 @@ Group:		%{ovirt_product_group}
 %mvn_package ":metamodel-tests" __noinstall
 
 %build
+# Necessary to override the default JVM for xmvn in COPR, which is JDK 8
+export JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
+
 %mvn_build -j
 
 


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>
