### PR TITLE
Skip metamodel-tests when building on COPR

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# git hash of current commit should be passed as the 1st paraameter
+# When building on GitHub we should use GITHUB_SHA environment variable, otherwise parse has from git
 if [ "${GITHUB_SHA}" == "" ]; then
   GIT_HASH=$(git rev-list HEAD | wc -l)
 else
@@ -9,6 +9,9 @@ fi
 
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter
 ARTIFACTS_DIR=${1:-exported-artifacts}
+
+# Disabling tests can be passed as the 2nd parameter
+SKIP_TESTS=${2:-0}
 
 # Prepare the version string (with support for SNAPSHOT versioning)
 VERSION=$(mvn help:evaluate  -q -DforceStdout -Dexpression=project.version)
@@ -25,6 +28,7 @@ git archive --format=tar HEAD | gzip -9 > rpmbuild/SOURCES/ovirt-engine-api-meta
 sed \
     -e "s|@VERSION@|${VERSION}|g" \
     -e "s|@RELEASE@|${RELEASE}|g" \
+    -e "s|@SKIP_TESTS@|${SKIP_TESTS}|g" \
     < ovirt-engine-api-metamodel.spec.in \
     > ovirt-engine-api-metamodel.spec
 

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -4,5 +4,5 @@ installdeps:
 	dnf -y install git gzip java-11-openjdk-devel make maven rpm-build sed
 
 srpm: installdeps
-	./.automation/build-srpm.sh
+	./.automation/build-srpm.sh exported-artifacts 1
 	cp rpmbuild/SRPMS/*.src.rpm $(outdir)

--- a/ovirt-engine-api-metamodel.spec.in
+++ b/ovirt-engine-api-metamodel.spec.in
@@ -1,3 +1,5 @@
+%global skip_tests @SKIP_TESTS@
+
 Name:		ovirt-engine-api-metamodel
 Version:	@VERSION@
 Release:	@RELEASE@%{?dist}
@@ -65,11 +67,16 @@ Group:		%{ovirt_product_group}
 # no need to package tests
 %mvn_package ":metamodel-tests" __noinstall
 
+%if %{?skip_tests}
+# We need to skip test execution on COPR due to some weld classloading issues
+%pom_remove_module metamodel-tests
+%endif
+
 %build
 # Necessary to override the default JVM for xmvn in COPR, which is JDK 8
 export JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
 
-%mvn_build -j -X -d
+%mvn_build -j
 
 
 %install


### PR DESCRIPTION
Skips execution of tests included in metamodel-tests submodule when
building on COPR because of weld classloading issues

Signed-off-by: Martin Perina <mperina@redhat.com>
