### PR TITLE
Use tests module name from pom.xml and not artifactdId

### DIFF
--- a/ovirt-engine-api-metamodel.spec.in
+++ b/ovirt-engine-api-metamodel.spec.in
@@ -69,7 +69,7 @@ Group:		%{ovirt_product_group}
 
 %if %{?skip_tests}
 # We need to skip test execution on COPR due to some weld classloading issues
-%pom_disable_module metamodel-tests
+%pom_disable_module tests
 %endif
 
 %build


### PR DESCRIPTION
Signed-off-by: Martin Perina <mperina@redhat.com>
