### PR TITLE
Bumpd asciidoctor version to 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <asciidoctor.version>1.6.0</asciidoctor.version>
+    <asciidoctor.version>1.6.2</asciidoctor.version>
     <antlr4.version>4.9.3</antlr4.version>
     <commons-cli.version>1.3.1</commons-cli.version>
     <commons-io.version>2.8.0</commons-io.version>


### PR DESCRIPTION
Bump asciidoctor version in pom.xml to match the asciidoctor provided by
RPM package.

Signed-off-by: Martin Perina <mperina@redhat.com>
