### PR TITLE
Upgrade to Weld 3

### DIFF
--- a/doctool/pom.xml
+++ b/doctool/pom.xml
@@ -82,7 +82,7 @@
     <!-- The tool runs in a CDI environment, implemented by Weld: -->
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se</artifactId>
+      <artifactId>weld-se-core</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <junit.version>4.13.1</junit.version>
     <qdox.version>2.0-M3</qdox.version>
     <slf4j.version>1.7.7</slf4j.version>
-    <weld-se.version>2.3.5.Final</weld-se.version>
+    <weld-se.version>3.1.9.Final</weld-se.version>
   </properties>
 
   <modules>
@@ -166,7 +166,7 @@
       <!-- The tool runs in a CDI environment, implemented by Weld: -->
       <dependency>
         <groupId>org.jboss.weld.se</groupId>
-        <artifactId>weld-se</artifactId>
+        <artifactId>weld-se-core</artifactId>
         <version>${weld-se.version}</version>
         <exclusions>
           <exclusion>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -76,7 +76,7 @@
     <!-- The tool runs in a CDI environment, implemented by Weld: -->
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se</artifactId>
+      <artifactId>weld-se-core</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Currently the tool fails to start the CDI container with the following error message:

```
[ERROR] Failed to execute goal
org.codehaus.mojo:exec-maven-plugin:3.0.0:java (generate-code) on
project metamodel-tests: An exception occured while executing the Java
class. WELD-001524: Unable to load proxy class for bean Implicit Bean
[javax.enterprise.inject.Instance] with qualifiers [@Default] with class
interface javax.enterprise.inject.Instance using classloader
java.net.URLClassLoader@2570b316: Could not initialize class
org.jboss.classfilewriter.ClassFile: Exception
java.lang.reflect.InaccessibleObjectException: Unable to make protected
final java.lang.Class
java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int)
throws java.lang.ClassFormatError accessible: module java.base does not
"opens java.lang" to unnamed module @5e407e1b [in thread
"weld-worker-7"] -> [Help 1]
```

I believe the reason for that is that the version of Weld that we use doesn't work well with Java 11 or later. This patch updates to Weld 3 to address that issue.