### PR TITLE
automation: drop el8 after centos stream 8 eol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: centos-stream-8
-            shortcut: cs8
-            container-name: el8stream
           - name: centos-stream-9
             shortcut: cs9
             container-name: el9stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Use cache for maven
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /root/.m2/repository
         key: ${{ matrix.shortcut }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -42,6 +42,6 @@ jobs:
         .automation/build-rpm.sh $ARTIFACTS_DIR
 
     - name: Upload artifacts
-      uses: ovirt/upload-rpms-action@v2
+      uses: ovirt/upload-rpms-action@main
       with:
         directory: ${{ env.ARTIFACTS_DIR }}


### PR DESCRIPTION
Dropping automation on el8 stream as centos stream 8 reached EOL.