### PR TITLE
pom: bump jakarta activation to version used by centos9 & 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <antlr4.version>4.9.3</antlr4.version>
     <commons-cli.version>1.3.1</commons-cli.version>
     <commons-io.version>2.14.0</commons-io.version>
-    <javax.activation.version>1.2.2</javax.activation.version>
+    <jakarta.activation.version>2.1.3</jakarta.activation.version>
     <javax.json.version>1.1.4</javax.json.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <jboss-jaxrs-api.version>1.0.0.Final</jboss-jaxrs-api.version>
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>jakarta.activation</groupId>
         <artifactId>jakarta.activation-api</artifactId>
-        <version>${javax.activation.version}</version>
+        <version>${jakarta.activation.version}</version>
       </dependency>
 
       <!-- This is needed to process Java source files: -->


### PR DESCRIPTION
Version specified in pom was outdated to actual needed and used version for jakarta or javax activation.